### PR TITLE
リサイズ時にスケルトンスクリーン化する

### DIFF
--- a/src/renderer/container/photo/PhotoGalleryContainer.tsx
+++ b/src/renderer/container/photo/PhotoGalleryContainer.tsx
@@ -153,7 +153,7 @@ const PhotoGalleryContainer: React.FC = () => {
     }[];
     const tmpRowIndexToItemIndexMap = new Map<number, string>();
 
-    if (photo === null) {
+    if (photo === null || isResizing) {
       const imageRow: JSX.Element[] = [];
       for (let i = 0; i < photoNumPerRow; i += 1) {
         imageRow.push(<Skeleton width="100%" height="100%" />);

--- a/src/renderer/container/search/SearchContainer.tsx
+++ b/src/renderer/container/search/SearchContainer.tsx
@@ -222,7 +222,7 @@ const SearchContainer: React.FC = () => {
     }[];
     const tmpRowIndexToItemIndexMap = new Map<number, string>();
 
-    if (isLoading) {
+    if (isLoading || isResizing) {
       const imageRow: JSX.Element[] = [];
       for (let i = 0; i < photoNumPerRow; i += 1) {
         imageRow.push(<Skeleton width={imageWidth} height={imageHeight - 8} />);

--- a/src/renderer/container/world/WorldGalleryContainer.tsx
+++ b/src/renderer/container/world/WorldGalleryContainer.tsx
@@ -140,7 +140,7 @@ const WorldGalleryContainer: React.FC = () => {
     }[];
     const tmpRowIndexToItemIndexMap = new Map<number, string>();
 
-    if (world === null) {
+    if (world === null || isResizing) {
       const imageRow: JSX.Element[] = [];
       for (let i = 0; i < photoNumPerRow; i += 1) {
         imageRow.push(<Skeleton width={imageWidth} height={imageHeight - 8} />);


### PR DESCRIPTION
リサイズ時に毎回リストを再計算すると重いのでスケルトンスクリーンにする